### PR TITLE
Adding the old PK back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ dist
 # https://nextjs.org/blog/next-9-1#public-directory-support
 # public
 
+#vscode
+settings.json
+
 # vuepress build output
 .vuepress/dist
 

--- a/src/example.ts
+++ b/src/example.ts
@@ -3,7 +3,7 @@ import {filfox} from "./schemas/filfox.js";
 import {collections} from "./types.js";
 
 const polydb = new Polybase({
-    defaultNamespace: 'pk/0x2d29bcb418989c5677641586d48fe51a5220875a0d82357bb9750c757c27cc73b2482666f4941bff3bc53c1d9b696dcab19351a5ac5c095f61e3d1f8ba91b90a',
+    defaultNamespace: 'pk/0x38d810a48aed860010ddd510ca9070b383490b3521972cdbd296d373dcd7183c8a885e1a2fd6fb2805216398a0ac5cf11a40ed452c3e4f893ca3ca794da3fbbf',
 })
 
 const provider = 'f01889512'


### PR DESCRIPTION
Adding the old PK back

This public key 0x38d810a48aed860010ddd510ca9070b383490b3521972cdbd296d373dcd7183c8a885e1a2fd6fb2805216398a0ac5cf11a40ed452c3e4f893ca3ca794da3fbbf

has been whitelisted to be used on main net. Since there is no existing schema on main net this should be fine to use.

0x2d29bcb418989c5677641586d48fe51a5220875a0d82357bb9750c757c27cc73b2482666f4941bff3bc53c1d9b696dcab19351a5ac5c095f61e3d1f8ba91b90a

should be used on test net.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/data-preservation-programs/RepPoly/pull/33).
* __->__ #33
* #32
* #31
* #6
* #2