### PR TITLE
Updating package to 1.0.8 Mainnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dataprograms/repdao-polybase",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dataprograms/repdao-polybase",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@dataprograms/repdao-polybase": "^1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dataprograms/repdao-polybase",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dataprograms/repdao-polybase",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@dataprograms/repdao-polybase": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dataprograms/repdao-polybase",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dataprograms/repdao-polybase",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export const DefaultNamespace = 'pk/0xf3e3d702ef1055c74e071ce744fe6449d4ddfaeaee
 
 export const DB = new Polybase({
     defaultNamespace: DefaultNamespace,
-    // baseURL: "https://mainnet.polybase.xyz/v0",
+    baseURL: "https://mainnet.polybase.xyz/v0",
 })
 
 export const collections: Collection[] = [


### PR DESCRIPTION
Updating package to 1.0.8 Mainnet

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/data-preservation-programs/RepPoly/pull/40).
* __->__ #40
* #39
* #38
* #37